### PR TITLE
amend to disk space calc

### DIFF
--- a/src/admin/class.admin.php
+++ b/src/admin/class.admin.php
@@ -46,7 +46,7 @@ class admin
 
         $spaceFree = disk_free_space('./');
         $totalSpace = disk_total_space('./');
-        $entries->space = round(($spaceFree/$totalSpace) * 100) . "%";
+        $entries->space = (100 - round((($totalSpace - $spaceFree)/$totalSpace) * 100)) . "%";
 
         if ($existingData) {
 


### PR DESCRIPTION
fix to disk space calculation.

previously it was using free space rather than used space in the percentage calculation.

due to rounding and factors involved the space available will likely show 100% for a while till a lot more files have been uploaded.